### PR TITLE
chore: release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [**breaking**] increase msrv to 1.85, add verification on CI ([#72](https://github.com/eigerco/beetswap/pull/72))
 - [**breaking**] upgrade deps and bump rust version to 1.83, add cargo-minimal-versions ([#70](https://github.com/eigerco/beetswap/pull/70))
-# Changelog
-All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-## [Unreleased]
 
 ## [0.4.1](https://github.com/eigerco/beetswap/compare/v0.4.0...v0.4.1) - 2025-03-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,19 @@
 # Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.5.0](https://github.com/eigerco/beetswap/compare/v0.4.1...v0.5.0) - 2025-09-09
+
+### Added
+
+- [**breaking**] increase msrv to 1.85, add verification on CI ([#72](https://github.com/eigerco/beetswap/pull/72))
+- [**breaking**] upgrade deps and bump rust version to 1.83, add cargo-minimal-versions ([#70](https://github.com/eigerco/beetswap/pull/70))
+# Changelog
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,7 +286,7 @@ checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 
 [[package]]
 name = "beetswap"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "asynchronous-codec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "beetswap"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Implementation of bitswap protocol for libp2p"


### PR DESCRIPTION



## 🤖 New release

* `beetswap`: 0.4.1 -> 0.5.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>


## [0.5.0](https://github.com/eigerco/beetswap/compare/v0.4.1...v0.5.0) - 2025-09-09

### Added

- [**breaking**] increase msrv to 1.85, add verification on CI ([#72](https://github.com/eigerco/beetswap/pull/72))
- [**breaking**] upgrade deps and bump rust version to 1.83, add cargo-minimal-versions ([#70](https://github.com/eigerco/beetswap/pull/70))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).